### PR TITLE
Update project tt_um_chip_rom (TinyTapeout/tt-chip-rom)

### DIFF
--- a/projects/tt_um_chip_rom/commit_id.json
+++ b/projects/tt_um_chip_rom/commit_id.json
@@ -3,7 +3,7 @@
   "repo": "https://github.com/TinyTapeout/tt-chip-rom",
   "commit": "e22570f04abf0fd86c947af862c72f491abb1716",
   "workflow_url": "https://github.com/TinyTapeout/tt-chip-rom/actions/runs/9444423792",
-  "sort_id": 1718006002578,
+  "sort_id": 1725704276573,
   "openlane_version": "OpenLane2 2.0.8",
   "pdk_version": "open_pdks bdc9412b3e468c102d01b7cf6337be06ec6e9c9a"
 }


### PR DESCRIPTION
Update project tt_um_chip_rom to commit TinyTapeout/tt-chip-rom@e22570f04abf0fd86c947af862c72f491abb1716

Project title: Chip ROM
Tiles: 1x1
Workflow: https://github.com/TinyTapeout/tt-chip-rom/actions/runs/9444423792

